### PR TITLE
Fix/release on failed acquire

### DIFF
--- a/src/mutex/mutex.spec.ts
+++ b/src/mutex/mutex.spec.ts
@@ -21,7 +21,7 @@ describe("Mutex", () => {
 
 	describe("`lock` usage", () => {
 		const delay = 50;
-		const offset = 3;
+		const offset = 5;
 
 		it("should work with a basic usage", async () => {
 			// semaphore as a mutex
@@ -114,7 +114,7 @@ describe("Mutex", () => {
 
 	describe("`tryLock` usage", () => {
 		const delay = 50;
-		const offset = 3;
+		const offset = 5;
 
 		it("should work with tryLock/unlock", async () => {
 			const mutex = new Mutex();

--- a/src/semaphore/semaphore.spec.ts
+++ b/src/semaphore/semaphore.spec.ts
@@ -264,8 +264,10 @@ describe("Semaphore", () => {
 			}, delay);
 
 			await Promise.all([
-				// second acquire in time
-				new Promise(resolve => setTimeout(resolve, 10)).then(() => semaphore.acquire(2)),
+				// `acquire` after the `tryAcquire`
+				new Promise(resolve => setTimeout(resolve, delay / 2)).then(() =>
+					semaphore.acquire(3)
+				),
 
 				semaphore
 					.tryAcquire(delay * 2, 3)
@@ -286,7 +288,7 @@ describe("Semaphore", () => {
 					})
 			]);
 
-			// The state is reset: 2 permits released for a single successful acquire (+ the initial one)
+			// The state is reset: 3 permits released for a single successful acquire (+ the initial one)
 			expect(semaphore.permitsAvailable).toBe(1);
 			expect(semaphore.permitsRequired).toBe(0);
 			expect(semaphore.queueLength).toBe(0);

--- a/src/semaphore/semaphore.spec.ts
+++ b/src/semaphore/semaphore.spec.ts
@@ -72,7 +72,7 @@ describe("Semaphore", () => {
 
 	describe("`acquire` usage", () => {
 		const delay = 50;
-		const offset = 3;
+		const offset = 5;
 
 		it("should work with a single initial permit", async () => {
 			// semaphore as a mutex
@@ -184,7 +184,7 @@ describe("Semaphore", () => {
 
 	describe("`tryAcquire` usage", () => {
 		const delay = 50;
-		const offset = 3;
+		const offset = 5;
 
 		it("should work with many initial tryAcquires/releases", async () => {
 			for (const permits of [5, 8, 13]) {


### PR DESCRIPTION
The available permits issued from the failed `tryAcquire` are used to balance the required ones:

1. `tryAcquire(time, 2)`
2. `acquire(2)`
3. 1 `release`
4. `tryAcquire` fails
  4.1. The _released_ permit is used for the `acquired in **2.**
5. 1 `release`
  5.1. the `acquire` in **2.** is free. 